### PR TITLE
chore: change build repo main to v23.05.2

### DIFF
--- a/configs-orangepi/config-default.conf
+++ b/configs-orangepi/config-default.conf
@@ -1,6 +1,6 @@
 # armbian repo settings
 ARMBIAN_REPOSITORY="armbian/build"
-ARMBIAN_BRANCH="main"
+ARMBIAN_BRANCH="v23.05.2"
 
 # orangepi-build repo settings
 ORANGEPI_REPOSITORY="orangepi-xunlong/orangepi-build"

--- a/configs/config-default.conf
+++ b/configs/config-default.conf
@@ -2,7 +2,7 @@
 
 # These variables are important for the mainsail-crew/armbian-builds workflow
 ARMBIAN_REPOSITORY="armbian/build"
-ARMBIAN_BRANCH="main"
+ARMBIAN_BRANCH="v23.05.2"
 
 # Read build script documentation https://docs.armbian.com/Developer-Guide_Build-Options/
 # for detailed explanation of these options and for additional options not listed here


### PR DESCRIPTION
This PR change the build branch of Armbian to the last stable release (v23.05.2)