### PR TITLE
fix: change orangepiOS kernel to next for opi zero 2

### DIFF
--- a/configs-orangepi/board-orangepi_zero2_bookworm.conf
+++ b/configs-orangepi/board-orangepi_zero2_bookworm.conf
@@ -1,2 +1,3 @@
 BOARD=orangepizero2
 RELEASE=bookworm
+KERNEL=next

--- a/configs-orangepi/board-orangepi_zero2_bullseye.conf
+++ b/configs-orangepi/board-orangepi_zero2_bullseye.conf
@@ -1,1 +1,2 @@
 BOARD=orangepizero2
+KERNEL=next


### PR DESCRIPTION
This change is needed because Orangepi no longer supports the "current" kernel.

https://github.com/orangepi-xunlong/orangepi-build/commit/35a14cacd18075ec875cd74fc59a9b61da87601a