### PR TITLE
chore: update armbian branch to v24.08

### DIFF
--- a/configs/board-bigtreetech_cb1_bookworm.conf
+++ b/configs/board-bigtreetech_cb1_bookworm.conf
@@ -1,3 +1,2 @@
 BOARD=bigtreetech-cb1
 RELEASE=bookworm
-BRANCH=legacy

--- a/configs/config-default.conf
+++ b/configs/config-default.conf
@@ -2,7 +2,7 @@
 
 # These variables are important for the mainsail-crew/armbian-builds workflow
 ARMBIAN_REPOSITORY="armbian/build"
-ARMBIAN_BRANCH="v24.05"
+ARMBIAN_BRANCH="v24.08"
 
 # Read build script documentation https://docs.armbian.com/Developer-Guide_Build-Options/
 # for detailed explanation of these options and for additional options not listed here


### PR DESCRIPTION
This PR update the ARMBIAN_BRANCH to v24.08 and change the cb1 bookworm image to current kernel.