### PR TITLE
chore: remove bullseye builds

### DIFF
--- a/configs-orangepi/board-orangepi_zero3_1500mb_bookworm.conf
+++ b/configs-orangepi/board-orangepi_zero3_1500mb_bookworm.conf
@@ -1,3 +1,2 @@
 BOARD=orangepizero3
-RELEASE=bookworm
 MEM_TYPE=1500MB

--- a/configs-orangepi/board-orangepi_zero3_1500mb_bullseye.conf
+++ b/configs-orangepi/board-orangepi_zero3_1500mb_bullseye.conf
@@ -1,2 +1,0 @@
-BOARD=orangepizero3
-MEM_TYPE=1500MB

--- a/configs-orangepi/board-orangepi_zero3_others_bookworm.conf
+++ b/configs-orangepi/board-orangepi_zero3_others_bookworm.conf
@@ -1,3 +1,2 @@
 BOARD=orangepizero3
-RELEASE=bookworm
 MEM_TYPE=Others

--- a/configs-orangepi/board-orangepi_zero3_others_bullseye.conf
+++ b/configs-orangepi/board-orangepi_zero3_others_bullseye.conf
@@ -1,2 +1,0 @@
-BOARD=orangepizero3
-MEM_TYPE=Others

--- a/configs-orangepi/config-default.conf
+++ b/configs-orangepi/config-default.conf
@@ -32,7 +32,7 @@ NO_APT_CACHER="yes"
 
 # setting for image
 BRANCH=current
-RELEASE=bullseye
+RELEASE=bookworm
 BUILD_OPT=image
 BUILD_MINIMAL=no
 BUILD_DESKTOP=no

--- a/configs/board-bananapi_m2_zero_bookworm.conf
+++ b/configs/board-bananapi_m2_zero_bookworm.conf
@@ -1,2 +1,1 @@
 BOARD=bananapim2zero
-RELEASE=bookworm

--- a/configs/board-bananapi_m2_zero_bullseye.conf
+++ b/configs/board-bananapi_m2_zero_bullseye.conf
@@ -1,1 +1,0 @@
-BOARD=bananapim2zero

--- a/configs/board-bigtreetech_cb1_bookworm.conf
+++ b/configs/board-bigtreetech_cb1_bookworm.conf
@@ -1,2 +1,1 @@
 BOARD=bigtreetech-cb1
-RELEASE=bookworm

--- a/configs/board-bigtreetech_cb1_bullseye.conf
+++ b/configs/board-bigtreetech_cb1_bullseye.conf
@@ -1,2 +1,0 @@
-BOARD=bigtreetech-cb1
-BRANCH=legacy

--- a/configs/board-orangepi3_lts_bookworm.conf
+++ b/configs/board-orangepi3_lts_bookworm.conf
@@ -1,2 +1,1 @@
 BOARD=orangepi3-lts
-RELEASE=bookworm

--- a/configs/board-orangepi3_lts_bullseye.conf
+++ b/configs/board-orangepi3_lts_bullseye.conf
@@ -1,1 +1,0 @@
-BOARD=orangepi3-lts

--- a/configs/board-orangepi4_lts_bookworm.conf
+++ b/configs/board-orangepi4_lts_bookworm.conf
@@ -1,2 +1,1 @@
 BOARD=orangepi4-lts
-RELEASE=bookworm

--- a/configs/board-orangepi4_lts_bullseye.conf
+++ b/configs/board-orangepi4_lts_bullseye.conf
@@ -1,1 +1,0 @@
-BOARD=orangepi4-lts

--- a/configs/board-orangepi_zero2_bookworm.conf
+++ b/configs/board-orangepi_zero2_bookworm.conf
@@ -1,2 +1,1 @@
 BOARD=orangepizero2
-RELEASE=bookworm

--- a/configs/board-orangepi_zero2_bullseye.conf
+++ b/configs/board-orangepi_zero2_bullseye.conf
@@ -1,1 +1,0 @@
-BOARD=orangepizero2

--- a/configs/board-rock_cm3_bookworm.conf
+++ b/configs/board-rock_cm3_bookworm.conf
@@ -1,2 +1,1 @@
 BOARD=rock-3a
-RELEASE=bookworm

--- a/configs/board-rock_cm3_bullseye.conf
+++ b/configs/board-rock_cm3_bullseye.conf
@@ -1,1 +1,0 @@
-BOARD=rock-3a

--- a/configs/board-rock_pi_4se_bookworm.conf
+++ b/configs/board-rock_pi_4se_bookworm.conf
@@ -1,2 +1,1 @@
 BOARD=rockpi-4b
-RELEASE=bookworm

--- a/configs/board-rock_pi_4se_bullseye.conf
+++ b/configs/board-rock_pi_4se_bullseye.conf
@@ -1,1 +1,0 @@
-BOARD=rockpi-4b

--- a/configs/config-default.conf
+++ b/configs/config-default.conf
@@ -30,7 +30,7 @@ CARD_DEVICE=""     # device name /dev/sdx of your SD card to burn directly to th
 # add default Variables for the mainsail-crew/armbian-builds images
 BETA="no"                   # disable warning in login screen
 BRANCH="current"            # use current kernel branch
-RELEASE="bullseye"          # create a debian/bullseye image
+RELEASE="bookworm"          # create a debian/bullseye image
 BUILD_MINIMAL="no"          # disable minimal to have more packages
 BUILD_DESKTOP="no"          # disable desktop, its not necessary for mainsailOS
 BOOTFS_TYPE="fat"           # use FAT filesystem for the /boot directory


### PR DESCRIPTION
This PR just remove all Bullseye images in the buildchain