### PR TITLE
Feat: add orangepi-zero-2w configs

### DIFF
--- a/configs/board-orangepi_zero2w_bookworm.conf
+++ b/configs/board-orangepi_zero2w_bookworm.conf
@@ -1,2 +1,1 @@
 BOARD=orangepizero2w
-RELEASE=bookworm

--- a/configs/board-orangepi_zero2w_bookworm.conf
+++ b/configs/board-orangepi_zero2w_bookworm.conf
@@ -1,0 +1,2 @@
+BOARD=orangepizero2w
+RELEASE=bookworm

--- a/configs/board-orangepi_zero2w_bullseye.conf
+++ b/configs/board-orangepi_zero2w_bullseye.conf
@@ -1,1 +1,0 @@
-BOARD=orangepizero2w

--- a/configs/board-orangepi_zero2w_bullseye.conf
+++ b/configs/board-orangepi_zero2w_bullseye.conf
@@ -1,0 +1,1 @@
+BOARD=orangepizero2w


### PR DESCRIPTION
Hopefully, MainsailOS can support the OrangePi Zero 2w!  Due to how the Zero 2W is very similar to the Zero 2 (but with wifi & bluetooth) this should not be hard to support. This supercedes #41 

The respective MainsailOS PR: https://github.com/mainsail-crew/MainsailOS/pull/312