### PR TITLE
ci: update runner from ubuntu-latest to ubuntu-24.04

### DIFF
--- a/.github/workflows/BuildTrain.yml
+++ b/.github/workflows/BuildTrain.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   setup:
     name: Create Matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -51,7 +51,7 @@ jobs:
 
   release:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       id: ${{ steps.release.outputs.id }}
       tag_name: ${{ steps.time.outputs.time }}
@@ -104,7 +104,7 @@ jobs:
   build-armbian:
     name: Armbian
     needs: [setup, release]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -174,7 +174,7 @@ jobs:
   build-orangepi:
     name: Orangepi
     needs: [ setup, release ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -233,7 +233,7 @@ jobs:
   finish:
     name: Finish BuildTrain
     needs: [release, build-armbian, build-orangepi]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Publish Release
         uses: eregon/publish-release@v1
@@ -246,7 +246,7 @@ jobs:
     name: Cleanup BuildTrain
     needs: [release, build-armbian, build-orangepi]
     if: ${{ always() }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Delete drafts
         uses: hugo19941994/delete-draft-releases@v1.0.0

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   setup:
     name: Create Matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
   build-armbian:
     name: Armbian
     needs: [ setup ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -165,7 +165,7 @@ jobs:
   build-orangepi:
     name: OPI
     needs: [ setup ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR replace the `ubuntu-latest` with `ubuntu-24.04` runner. But the `ubuntu-24.04` runner will be soon the default runner. So this was more like a test if all works with the new runners.