### PR TITLE
chore: remove cb1 bullseye config

### DIFF
--- a/configs/board-bigtreetech_cb1_bullseye.conf
+++ b/configs/board-bigtreetech_cb1_bullseye.conf
@@ -1,1 +1,0 @@
-BOARD=bigtreetech-cb1


### PR DESCRIPTION
This PR just removes the CB1 bullseye config. Looks like i forgot it in the remove bullseye PR.