### PR TITLE
fix: change orangepizero3 to next kernel branch

### DIFF
--- a/configs-orangepi/board-orangepi_zero3_1500mb_bookworm.conf
+++ b/configs-orangepi/board-orangepi_zero3_1500mb_bookworm.conf
@@ -1,2 +1,3 @@
 BOARD=orangepizero3
 MEM_TYPE=1500MB
+BRANCH=next

--- a/configs-orangepi/board-orangepi_zero3_others_bookworm.conf
+++ b/configs-orangepi/board-orangepi_zero3_others_bookworm.conf
@@ -1,2 +1,3 @@
 BOARD=orangepizero3
 MEM_TYPE=Others
+BRANCH=next


### PR DESCRIPTION
This PR change the Kernel branch from current to next on both orangepi zero3 images. This have to be done, because Orangepi only allow bookworm images on this branch. Here is the board config for this: https://github.com/orangepi-xunlong/orangepi-build/blob/f9817ec523fd8add9435ad0c1c13f0b36f371980/external/config/boards/orangepizero3.conf#L13