### PR TITLE
chore: remove bookworm images

### DIFF
--- a/configs/board-bigtreetech_cb1_bookworm.conf
+++ b/configs/board-bigtreetech_cb1_bookworm.conf
@@ -1,1 +1,0 @@
-BOARD=bigtreetech-cb1

--- a/configs/board-bigtreetech_cb2_bookworm.conf
+++ b/configs/board-bigtreetech_cb2_bookworm.conf
@@ -1,1 +1,0 @@
-BOARD=bigtreetech-cb2

--- a/configs/board-orangepi3_lts_bookworm.conf
+++ b/configs/board-orangepi3_lts_bookworm.conf
@@ -1,1 +1,0 @@
-BOARD=orangepi3-lts

--- a/configs/board-orangepi4_lts_bookworm.conf
+++ b/configs/board-orangepi4_lts_bookworm.conf
@@ -1,1 +1,0 @@
-BOARD=orangepi4-lts

--- a/configs/board-orangepi_zero2_bookworm.conf
+++ b/configs/board-orangepi_zero2_bookworm.conf
@@ -1,1 +1,0 @@
-BOARD=orangepizero2

--- a/configs/board-orangepi_zero2w_bookworm.conf
+++ b/configs/board-orangepi_zero2w_bookworm.conf
@@ -1,1 +1,0 @@
-BOARD=orangepizero2w

--- a/configs/board-orangepi_zero3_bookworm.conf
+++ b/configs/board-orangepi_zero3_bookworm.conf
@@ -1,1 +1,0 @@
-BOARD=orangepizero3

--- a/configs/board-rock_cm3_bookworm.conf
+++ b/configs/board-rock_cm3_bookworm.conf
@@ -1,1 +1,0 @@
-BOARD=rock-3a

--- a/configs/board-rock_pi_4se_bookworm.conf
+++ b/configs/board-rock_pi_4se_bookworm.conf
@@ -1,1 +1,0 @@
-BOARD=rockpi-4b

--- a/configs/config-default.conf
+++ b/configs/config-default.conf
@@ -30,7 +30,7 @@ CARD_DEVICE=""     # device name /dev/sdx of your SD card to burn directly to th
 # add default Variables for the mainsail-crew/armbian-builds images
 BETA="no"                   # disable warning in login screen
 BRANCH="current"            # use current kernel branch
-RELEASE="bookworm"          # create a debian/bullseye image
+RELEASE="trixie"          # create a debian/bullseye image
 BUILD_MINIMAL="no"          # disable minimal to have more packages
 BUILD_DESKTOP="no"          # disable desktop, its not necessary for mainsailOS
 BOOTFS_TYPE="fat"           # use FAT filesystem for the /boot directory

--- a/configs/config-default.conf
+++ b/configs/config-default.conf
@@ -30,7 +30,7 @@ CARD_DEVICE=""     # device name /dev/sdx of your SD card to burn directly to th
 # add default Variables for the mainsail-crew/armbian-builds images
 BETA="no"                   # disable warning in login screen
 BRANCH="current"            # use current kernel branch
-RELEASE="trixie"          # create a debian/bullseye image
+RELEASE="trixie"            # which Debian release should be created
 BUILD_MINIMAL="no"          # disable minimal to have more packages
 BUILD_DESKTOP="no"          # disable desktop, its not necessary for mainsailOS
 BOOTFS_TYPE="fat"           # use FAT filesystem for the /boot directory


### PR DESCRIPTION
This PR removes all bookworm images, because MainsailOS switched to Trixie.